### PR TITLE
Implement Parcelizer scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,8 @@ This repository contains example parcel boundary images for development and test
 - `elkins tract 2 use this one.pdf` - Second example parcel boundary map
 
 These files serve as reference materials for parcel boundary analysis and processing. 
+## Parcelizer Project
+
+The `parcelizer/` directory contains a Poetry project implementing the Parcelizer tool.
+
+Use `poetry install` and see the project README for usage.

--- a/parcelizer/README.md
+++ b/parcelizer/README.md
@@ -1,0 +1,26 @@
+# Parcelizer
+
+Local-first tool to extract parcel boundaries from images using OpenAI vision and Regrid API.
+
+## Installation
+
+```bash
+# Requires Python 3.11 and Poetry
+poetry install
+```
+
+## Usage
+
+CLI:
+
+```bash
+poetry run parcelizer path/to/parcel_image.png
+```
+
+Web UI:
+
+```bash
+poetry run python -m parcelizer.web
+```
+
+Then open <http://127.0.0.1:8080> in your browser.

--- a/parcelizer/parcelizer/src/parcelizer/__init__.py
+++ b/parcelizer/parcelizer/src/parcelizer/__init__.py
@@ -1,0 +1,8 @@
+"""Parcelizer package."""
+from importlib.metadata import PackageNotFoundError, version
+
+__all__ = ["__version__"]
+try:
+    __version__ = version("parcelizer")
+except PackageNotFoundError:  # pragma: no cover - not installed
+    __version__ = "0.0.0"

--- a/parcelizer/parcelizer/src/parcelizer/__main__.py
+++ b/parcelizer/parcelizer/src/parcelizer/__main__.py
@@ -1,0 +1,3 @@
+from .cli import main
+
+main()

--- a/parcelizer/parcelizer/src/parcelizer/cli.py
+++ b/parcelizer/parcelizer/src/parcelizer/cli.py
@@ -1,0 +1,37 @@
+"""CLI entry point for Parcelizer."""
+from __future__ import annotations
+
+import asyncio
+from argparse import ArgumentParser
+from pathlib import Path
+
+import httpx
+
+from .ocr import extract_text
+from .vision import extract_metadata
+from .regrid import fetch_by_apn, fetch_by_address
+from .utils import save_geojson, save_vertices
+
+
+async def run(path: Path) -> None:
+    text = extract_text(path)
+    metadata = await extract_metadata(path, text)
+    async with httpx.AsyncClient() as client:
+        if "parcel_id" in metadata:
+            geom = await fetch_by_apn(metadata["parcel_id"], client)
+        else:
+            geom = await fetch_by_address(metadata.get("address", ""), client)
+    parcel_id = metadata.get("parcel_id", "unknown")
+    save_geojson(parcel_id, geom)
+    save_vertices(parcel_id, geom)
+    print(f"Saved parcel {parcel_id}")
+
+
+def main() -> None:
+    parser = ArgumentParser(description="Parcelizer CLI")
+    parser.add_argument("file", type=Path)
+    args = parser.parse_args()
+    asyncio.run(run(args.file))
+
+if __name__ == "__main__":
+    main()

--- a/parcelizer/parcelizer/src/parcelizer/ocr.py
+++ b/parcelizer/parcelizer/src/parcelizer/ocr.py
@@ -1,0 +1,25 @@
+"""OCR utilities using Tesseract."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+from PIL import Image
+import pytesseract
+
+
+def load_images(path: Path) -> List[Image.Image]:
+    """Load images from a file which may be PDF or an image."""
+    if path.suffix.lower() == ".pdf":
+        try:
+            from pdf2image import convert_from_path
+        except ImportError as exc:  # pragma: no cover - external
+            raise RuntimeError("pdf2image required for PDF support") from exc
+        return convert_from_path(str(path))
+    return [Image.open(path)]
+
+
+def extract_text(path: Path) -> str:
+    """Run OCR on given file and return extracted text."""
+    images = load_images(path)
+    text_parts = [pytesseract.image_to_string(img) for img in images]
+    return "\n".join(text_parts)

--- a/parcelizer/parcelizer/src/parcelizer/regrid.py
+++ b/parcelizer/parcelizer/src/parcelizer/regrid.py
@@ -1,0 +1,30 @@
+"""Client for Regrid Parcel API v2."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import httpx
+
+REGRID_URL = "https://api.regrid.com/v2/parcels"
+REGRID_API_KEY = os.getenv("REGRID_API_KEY", "")
+
+
+async def fetch_by_apn(apn: str, client: httpx.AsyncClient):
+    """Fetch parcel geometry by APN."""
+    params = {"apn": apn, "token": REGRID_API_KEY}
+    resp = await client.get(f"{REGRID_URL}/apn", params=params)
+    resp.raise_for_status()
+    from shapely.geometry import shape
+    geojson = resp.json()["features"][0]["geometry"]
+    return shape(geojson)
+
+
+async def fetch_by_address(address: str, client: httpx.AsyncClient):
+    """Fetch parcel geometry by address."""
+    params = {"address": address, "token": REGRID_API_KEY}
+    resp = await client.get(f"{REGRID_URL}/address", params=params)
+    resp.raise_for_status()
+    from shapely.geometry import shape
+    geojson = resp.json()["features"][0]["geometry"]
+    return shape(geojson)

--- a/parcelizer/parcelizer/src/parcelizer/utils.py
+++ b/parcelizer/parcelizer/src/parcelizer/utils.py
@@ -1,0 +1,46 @@
+"""Utility helpers for Parcelizer."""
+from __future__ import annotations
+
+from pathlib import Path
+import csv
+import json
+
+def _mapping(geometry):
+    """Return GeoJSON mapping for ``geometry`` without importing globally."""
+    from shapely.geometry import mapping
+    return mapping(geometry)
+
+
+OUTPUT_DIR = Path("output")
+OUTPUT_DIR.mkdir(exist_ok=True)
+
+
+def save_geojson(parcel_id: str, geometry) -> Path:
+    """Save geometry to a GeoJSON file in ``OUTPUT_DIR``.
+
+    Parameters
+    ----------
+    parcel_id:
+        Identifier for file naming.
+    geometry:
+        Shapely geometry object.
+    Returns
+    -------
+    Path to the saved file.
+    """
+    path = OUTPUT_DIR / f"{parcel_id}.geojson"
+    with path.open("w", encoding="utf-8") as fh:
+        json.dump({"type": "Feature", "geometry": _mapping(geometry)}, fh)
+    return path
+
+
+def save_vertices(parcel_id: str, geometry) -> Path:
+    """Save vertices of ``geometry`` to CSV in ``OUTPUT_DIR``."""
+    path = OUTPUT_DIR / f"{parcel_id}_vertices.csv"
+    coords = list(geometry.exterior.coords)
+    with path.open("w", newline="", encoding="utf-8") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(["lat", "lon"])
+        for lon, lat in coords:
+            writer.writerow([lat, lon])
+    return path

--- a/parcelizer/parcelizer/src/parcelizer/vision.py
+++ b/parcelizer/parcelizer/src/parcelizer/vision.py
@@ -1,0 +1,42 @@
+"""Vision extraction via OpenAI."""
+from __future__ import annotations
+
+from pathlib import Path
+import base64
+import asyncio
+import json
+
+import openai
+
+
+SYSTEM_PROMPT = "You extract parcel identifiers from maps."
+USER_TEMPLATE = (
+    "Given the following OCR text and image, extract JSON with keys 'parcel_id' "
+    "and 'address', plus any county or state clues."
+)
+
+
+async def extract_metadata(image: Path, ocr_text: str) -> dict:
+    """Extract parcel metadata from image and OCR text using OpenAI."""
+    with image.open("rb") as fh:
+        img_b64 = base64.b64encode(fh.read()).decode()
+    client = openai.AsyncClient()
+    response = await client.chat.completions.create(
+        model="o4-mini-vision-latest",
+        messages=[
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": USER_TEMPLATE + "\n" + ocr_text},
+                    {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{img_b64}"}},
+                ],
+            },
+        ],
+        max_tokens=256,
+    )
+    content = response.choices[0].message.content
+    try:
+        return json.loads(content)
+    except json.JSONDecodeError:
+        return {}

--- a/parcelizer/parcelizer/src/parcelizer/web.py
+++ b/parcelizer/parcelizer/src/parcelizer/web.py
@@ -1,0 +1,75 @@
+"""Flask web UI for Parcelizer."""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from flask import Flask, render_template_string, request, jsonify
+import httpx
+
+from .ocr import extract_text
+from .vision import extract_metadata
+from .regrid import fetch_by_apn, fetch_by_address
+from .utils import save_geojson, save_vertices
+
+
+template = """
+<!doctype html>
+<html><head>
+<meta charset="utf-8">
+<title>Parcelizer</title>
+<link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+</head>
+<body>
+<h1>Parcelizer</h1>
+<form id="form"><input type="file" name="file" id="file" /></form>
+<div id="map" style="height:500px"></div>
+<script>
+const fileInput = document.getElementById('file');
+fileInput.onchange = async () => {
+  const fd = new FormData();
+  fd.append('file', fileInput.files[0]);
+  const res = await fetch('/process', {method: 'POST', body: fd});
+  const data = await res.json();
+  const map = L.map('map').setView([0,0],1);
+  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {attribution:'© OSM'}).addTo(map);
+  const geo = L.geoJSON(data.geojson).addTo(map);
+  map.fitBounds(geo.getBounds());
+};
+</script>
+</body></html>
+"""
+
+
+def create_app() -> Flask:
+    app = Flask(__name__)
+
+    @app.get("/")
+    def index() -> str:
+        return render_template_string(template)
+
+    @app.post("/process")
+    async def process() -> tuple[str, int]:
+        file = request.files["file"]
+        path = Path("/tmp") / file.filename
+        file.save(path)
+        text = extract_text(path)
+        metadata = await extract_metadata(path, text)
+        async with httpx.AsyncClient() as client:
+            if "parcel_id" in metadata:
+                geom = await fetch_by_apn(metadata["parcel_id"], client)
+            else:
+                geom = await fetch_by_address(metadata.get("address", ""), client)
+        save_geojson(metadata.get("parcel_id", "unknown"), geom)
+        save_vertices(metadata.get("parcel_id", "unknown"), geom)
+        return jsonify({"geojson": {"type": "Feature", "geometry": geom.__geo_interface__}}), 200
+
+    return app
+
+
+def main() -> None:
+    app = create_app()
+    app.run(port=8080, debug=True)
+
+if __name__ == "__main__":
+    main()

--- a/parcelizer/pyproject.toml
+++ b/parcelizer/pyproject.toml
@@ -1,0 +1,27 @@
+[project]
+name = "parcelizer"
+version = "0.1.0"
+description = ""
+authors = [
+    {name = "Codex",email = "codex@openai.com"}
+]
+readme = "README.md"
+requires-python = ">=3.11,<3.12"
+dependencies = [
+    "openai",
+    "httpx",
+    "pillow",
+    "pytesseract",
+    "shapely",
+    "geopandas",
+    "flask",
+    "aiofiles",
+]
+
+
+[build-system]
+requires = ["poetry-core>=2.0.0,<3.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[project.scripts]
+parcelizer = "parcelizer.cli:main"

--- a/parcelizer/tests/test_utils.py
+++ b/parcelizer/tests/test_utils.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+from parcelizer import utils
+
+class FakeGeom:
+    def __init__(self):
+        self.exterior = self
+        self._coords = [(0, 0), (1, 0), (1, 1), (0, 1), (0, 0)]
+
+    @property
+    def coords(self):
+        return self._coords
+
+
+def test_save_geojson_and_vertices(tmp_path: Path, monkeypatch):
+    utils.OUTPUT_DIR = tmp_path
+    monkeypatch.setattr(utils, "_mapping", lambda g: {"type": "Polygon", "coordinates": [[[0,0],[1,0],[1,1],[0,1],[0,0]]]})
+    geom = FakeGeom()
+    geo_path = utils.save_geojson("x", geom)
+    csv_path = utils.save_vertices("x", geom)
+    assert geo_path.exists()
+    assert csv_path.exists()
+    data = geo_path.read_text()
+    assert "Feature" in data
+    lines = csv_path.read_text().splitlines()
+    assert lines[0] == "lat,lon"


### PR DESCRIPTION
## Summary
- add Parcelizer project with OCR, OpenAI, and Regrid API modules
- implement CLI and Flask web server
- provide basic test for utility helpers
- document usage in README

## Testing
- `PYTHONPATH=./parcelizer/parcelizer/src pytest -q parcelizer/tests/test_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_6844b08c07588324945b38ad210ad9af